### PR TITLE
Enhancement: show palette editor by sessionStorage value

### DIFF
--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -50,6 +50,7 @@ export const defaultConfig: Config = {
     signUpUrl: '',
     logoUrl: '',
     logoDarkUrl: '',
+    sonic: false,
 };
 
 export const Cryptobase = {
@@ -100,3 +101,4 @@ export const signInUrl = (): string => Cryptobase.config.signInUrl;
 export const signUpUrl = (): string => Cryptobase.config.signUpUrl;
 export const logoUrl = (): string => Cryptobase.config.logoUrl;
 export const logoDarkUrl = (): string => Cryptobase.config.logoDarkUrl;
+export const isSonicEnabled = () => convertToBoolean(Cryptobase.config.sonic);

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -43,6 +43,7 @@ declare global {
         signUpUrl: string;
         logoUrl: string;
         logoDarkUrl: string;
+        sonic?: string | boolean;
     }
 
     interface Window {

--- a/web/src/containers/Customization/index.tsx
+++ b/web/src/containers/Customization/index.tsx
@@ -136,9 +136,12 @@ class CustomizationContainer extends React.Component<Props, State> {
         const { currentTabIndex, isOpen } = this.state;
 
         if (
-            !userLoggedIn ||
-            user?.role !== 'superadmin' ||
-            location.pathname === '/setup'
+            (
+                !userLoggedIn ||
+                user?.role !== 'superadmin' ||
+                location.pathname === '/setup'
+            ) &&
+            window.sessionStorage.getItem('palette/show') !== 'true'
         ) {
             return null;
         }
@@ -226,6 +229,11 @@ class CustomizationContainer extends React.Component<Props, State> {
                 header_logo: headerLogo,
             };
         };
+
+        if (window.sessionStorage.getItem('palette/show') === 'true') {
+            window.sessionStorage.setItem('palette/data', JSON.stringify(settings));
+            window.console.log('palette', settings);
+        }
 
         this.props.configUpdate({
             component: 'global',

--- a/web/src/helpers/customizationSettings.ts
+++ b/web/src/helpers/customizationSettings.ts
@@ -10,7 +10,7 @@ export const clearCustomizationSettings = () => {
     const rootElement = document.documentElement;
     const bodyElement = document.querySelector<HTMLElement>('body')!;
 
-    if (rootElement) {    
+    if (rootElement) {
         AVAILABLE_COLOR_TITLES.reduce((result, item) => {
             rootElement.style.removeProperty(item.key);
 
@@ -31,8 +31,13 @@ export const applyCustomizationSettingsColors = (
     customization?: CustomizationSettingsInterface,
     toggleChartRebuild?: () => void,
 ) => {
-    const settingsFromConfig: CustomizationSettingsInterface | undefined =
+    let settingsFromConfig: CustomizationSettingsInterface | undefined =
         window.env?.palette ? JSON.parse(window.env.palette) : undefined;
+
+    if (!settingsFromConfig && window.sessionStorage.getItem('palette/show') === 'true') {
+        settingsFromConfig = JSON.parse(window.sessionStorage.getItem('palette/data'));
+    }
+
     const rootElement = document.documentElement;
     const bodyElement = document.querySelector<HTMLElement>('body')!;
     let shouldChartRebuild = false;
@@ -41,7 +46,7 @@ export const applyCustomizationSettingsColors = (
         AVAILABLE_COLOR_TITLES.reduce((result, item) => {
             let darkModeColor = undefined;
             let lightModeColor = undefined;
-    
+
             if (customization?.theme_colors?.dark) {
                 darkModeColor = customization.theme_colors.dark.find((color => color.key === item.key));
             }

--- a/web/src/helpers/jest.ts
+++ b/web/src/helpers/jest.ts
@@ -44,11 +44,16 @@ const mockConfig: Config = {
         'address'
     ],
     themeSwitcher: 'visible',
+    captcha_id: undefined,
+    captcha_type: 'none',
+    password_min_entropy: 0,
+
     openOrdersFetchInterval: '10000',
     signInUrl: '',
     signUpUrl: '',
     logoUrl: '',
     logoDarkUrl: '',
+    sonic: false,
 };
 
 // tslint:disable no-any no-console

--- a/web/src/modules/admin/config/sagas/configUpdateSaga.ts
+++ b/web/src/modules/admin/config/sagas/configUpdateSaga.ts
@@ -1,7 +1,7 @@
 import { call, put } from 'redux-saga/effects';
 import { sendError } from '../../../';
 import { getCsrfToken } from '../../../../helpers';
-import { API, RequestOptions } from '../../../../api';
+import { API, RequestOptions, isSonicEnabled } from '../../../../api';
 import { ConfigUpdate, configUpdateData, configUpdateError } from '../actions';
 
 const configUpdateOptions = (csrfToken?: string): RequestOptions => {
@@ -20,7 +20,9 @@ export function* configUpdateSaga(action: ConfigUpdate) {
             value,
         };
 
-        yield call(API.put(configUpdateOptions(getCsrfToken())), `/admin/${action.payload.component}/secret`, payload);
+        if (isSonicEnabled()) {
+            yield call(API.put(configUpdateOptions(getCsrfToken())), `/admin/${action.payload.component}/secret`, payload);
+        }
         yield put(configUpdateData(action.payload));
     } catch (error) {
         yield put(sendError({


### PR DESCRIPTION
Включение кнопки настройки цветов:
- открыть devtools браузера (F12)
- перейти на закладку Console
- вбить следующий код: `window.sessionStorage.setItem('palette/show', 'true')`
- перезагрузить страницу
- появится зеленая иконка палитры в правом нижнем углу

Сохранение темы после изменений цветов:
- открыть devtools/Console
- нажать Save
- в консоли появится строчка `palette { theme_colors: {...} ...}`
- над theme_colors вызвать контектное меню > `Copy object`
- получившийся текст можно отправить сообщением