### PR TITLE
Fix the loading of env.js for the devdax

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -84,7 +84,7 @@
         "mockAPI": "node mocks/mockAPI.js",
         "mockWS": "node mocks/mockWS.js",
         "start": "cross-env NODE_OPTIONS=--max_old_space_size=2048 webpack-dev-server --config ./webpack/development.ts",
-        "start-mock": "npm-run-all -p start mockAPI mockWS",
+        "start-mock": "cross-env MOCK=1 npm-run-all -p start mockAPI mockWS",
         "build": "cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=4096 webpack --config ./webpack/production.ts",
         "analyze": "cross-env ANALYZE=1 NODE_ENV=production NODE_OPTIONS=--max_old_space_size=4096 webpack --config ./webpack/production.ts  --profile --json > stats.json",
         "test": "jest --config jest.config.js --silent",

--- a/web/src/app/template_dev.html
+++ b/web/src/app/template_dev.html
@@ -13,10 +13,10 @@
         <title>Cryptobase</title>
     </head>
     <body>
-        <% if (htmlWebpackPlugin.options.PROXY_HOST) { %>
-            <script src="/config/env.js"></script>
-        <% } else { %>
+        <% if (htmlWebpackPlugin.options.mock) { %>
             <script src="/config.js"></script>
+        <% } else { %>
+            <script src="/config/env.js"></script>
         <% } %>
         <noscript>
             You need to enable JavaScript to run this app.

--- a/web/webpack/development.ts
+++ b/web/webpack/development.ts
@@ -19,7 +19,7 @@ const config = merge(commonConfig, {
             template: path.resolve(rootDir, 'src/app/template_dev.html'),
             hash: true,
             chunks: ['common', 'bundle', 'styles'],
-            PROXY_HOST: host,
+            mock: process.env.MOCK,
         }),
     ],
     module: {


### PR DESCRIPTION
При починке команды `yarn start-mock` не учел запуск из devdax. Теперь заведена явная переменная `mock`