### PR TITLE
Fix alignment for WalletItem

### DIFF
--- a/web/src/components/WalletItem/index.tsx
+++ b/web/src/components/WalletItem/index.tsx
@@ -3,7 +3,6 @@ import { Wallet } from '../../modules';
 import { CryptoIcon } from '../CryptoIcon';
 import { Decimal } from '../Decimal';
 
-
 const style: React.CSSProperties = {
     display: 'flex',
     justifyContent: 'space-between',

--- a/web/src/screens/WalletsScreen/WalletsScreen.pcss
+++ b/web/src/screens/WalletsScreen/WalletsScreen.pcss
@@ -67,6 +67,12 @@
       &__info {
         align-items: center;
 
+        .cr-wallet-item__icon {
+          img {
+            margin-right: 0;
+          }
+        }
+
         .cr-wallet-item__image-icon {
           margin-left: calc(var(--gap) * 2);
           margin-right: calc(var(--gap) * 1.5);
@@ -88,7 +94,7 @@
             color: var(--wallets-locked-amount);
             font-size: calc(var(--gap) * 1.9);
             font-weight: normal;
-            margin-top: calc(var(--gap) * 0.6);
+            margin-top: calc(var(--gap) * 0.3);
             opacity: 0.3;
           }
         }


### PR DESCRIPTION
Fixes bitzlato/baseapp#39

Ещё подвинул текст ближе к иконке
![example](https://user-images.githubusercontent.com/2435004/129355056-16aa56d5-e076-444c-a9c9-12b7893bd157.png)
