### PR TITLE
Change the deposit status presentation

### DIFF
--- a/web/src/components/History/DepositStatus.tsx
+++ b/web/src/components/History/DepositStatus.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { getBlockchainLink } from 'src/helpers/getBlockchainLink';
+import { selectCurrencies, selectWallets } from 'src/modules';
+import { Deposit } from 'src/modules/user/history/types';
+import { Status } from './Status';
+import { SucceedIcon } from '../../containers/Wallets/SucceedIcon';
+import { useT } from 'src/hooks/useT';
+import { ExternalLink } from './ExternalLink';
+
+interface Props {
+    currency: string;
+    item: Deposit;
+}
+
+export const DepositStatus: React.FC<Props> = ({ item, currency }) => {
+    const t = useT();
+    switch (item.state) {
+        case 'dispatched':
+            return (
+                <Status type="success">
+                    <SucceedIcon />
+                </Status>
+            );
+        case 'errored':
+            return item.public_message ? (
+                <Status type="failed">{item.public_message}</Status>
+            ) : (
+                <Status type="failed">{t('page.body.history.deposit.content.status.skipped')}</Status>
+            );
+        case 'skipped':
+            return <Status type="failed">{t('page.body.history.deposit.content.status.skipped')}</Status>;
+        case 'rejected':
+            return <Status type="failed">{t('page.body.history.deposit.content.status.canceled')}</Status>;
+        case 'submitted':
+            return <Status type="pending">{t('page.body.history.deposit.content.status.processing')}</Status>;
+        case 'invoiced':
+            return item.transfer_links ? (
+                <div className="cr-row-spacing">
+                    {item.transfer_links.map(d => (
+                        <ExternalLink key={d.title} href={d.url}>
+                            <Status type="pending">{d.title}</Status>
+                        </ExternalLink>
+                    ))}
+                </div>
+            ) : (
+                <Status type="pending">{t('page.body.wallets.table.invoiced')}</Status>
+            );
+        case 'canceled':
+            return <Status type="failed">{t('page.body.history.deposit.content.status.canceled')}</Status>;
+        case 'accepted':
+            return <DepositStatusAccepted item={item} currency={currency} />;
+        case 'refunding':
+            return <Status type="pending">{t('page.body.history.deposit.content.status.refunding')}</Status>;
+        default:
+            return <Status type="failed">{item.state}</Status>;
+    }
+};
+
+const DepositStatusAccepted: React.FC<Props> = ({ item, currency }) => {
+    const t = useT();
+    const wallets = useSelector(selectWallets);
+    const currencies = useSelector(selectCurrencies);
+    const blockchainLink = getBlockchainLink(wallets, currency, item.txid);
+    const itemCurrency = currencies.find(cur => cur.id === currency);
+    const min: number | undefined = itemCurrency?.min_confirmations;
+    const content = t('page.body.wallets.table.pending') + (min !== undefined ? ` ${item.confirmations}/${min}` : '');
+    return (
+        <ExternalLink href={blockchainLink}>
+            <Status type="pending">{content}</Status>
+        </ExternalLink>
+    );
+};

--- a/web/src/components/History/ExternalLink.tsx
+++ b/web/src/components/History/ExternalLink.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+interface Props {
+    href: string;
+}
+
+export const ExternalLink: React.FC<Props> = props => (
+    <a href={props.href} target="_blank" rel="noopener noreferrer">
+        {props.children}
+    </a>
+);

--- a/web/src/components/History/Status.tsx
+++ b/web/src/components/History/Status.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+interface Props {
+    type: 'success' | 'failed' | 'pending';
+    style?: React.CSSProperties;
+}
+
+export const Status: React.FC<Props> = props => (
+    <span className={`cr-mobile-history-table--${props.type}`} style={props.style}>
+        {props.children}
+    </span>
+);

--- a/web/src/components/History/TransferLinks.tsx
+++ b/web/src/components/History/TransferLinks.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { TransferLink } from '../../modules/user/history';
+import { ExternalLink } from './ExternalLink';
+
+interface Props {
+    links: TransferLink[];
+}
+
+export const TransferLinks: React.FC<Props> = props => (
+    <div className="cr-row-spacing">
+        {props.links.map(d => (
+            <ExternalLink key={d.title} href={d.url}>
+                {d.title}
+            </ExternalLink>
+        ))}
+    </div>
+);

--- a/web/src/components/Markets/__snapshots__/Markets.test.tsx.snap
+++ b/web/src/components/Markets/__snapshots__/Markets.test.tsx.snap
@@ -347,6 +347,7 @@ exports[`Markets should render empty data 1`] = `
         "page.body.history.deposit.content.status.errored": "Errored",
         "page.body.history.deposit.content.status.fee_processing": "Processing",
         "page.body.history.deposit.content.status.processing": "Processing",
+        "page.body.history.deposit.content.status.refunding": "Refunding",
         "page.body.history.deposit.content.status.rejected": "Rejected",
         "page.body.history.deposit.content.status.skipped": "Skipped",
         "page.body.history.deposit.content.status.submitted": "Submitted",

--- a/web/src/containers/Wallets/SucceedIcon.tsx
+++ b/web/src/containers/Wallets/SucceedIcon.tsx
@@ -6,7 +6,7 @@ export const SucceedIcon = () => {
         <svg width="10" height="8" viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path
                 d="M9 1L3.68517 7L1 4.47371"
-                stroke="#737F92"
+                stroke="currentColor"
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"

--- a/web/src/custom/translations/ru.ts
+++ b/web/src/custom/translations/ru.ts
@@ -328,6 +328,7 @@ export const ru: LangType = {
     'page.body.history.deposit.content.status.processing': 'Обрабатывается',
     'page.body.history.deposit.content.status.fee_processing': 'Обрабатывается',
     'page.body.history.deposit.content.status.errored': 'Ошибка',
+    'page.body.history.deposit.content.status.refunding': 'Refunding',
 
     'page.body.history.withdraw': 'История выводов',
     'page.body.history.withdraw.header.id': 'ID',

--- a/web/src/helpers/getBlockchainLink.ts
+++ b/web/src/helpers/getBlockchainLink.ts
@@ -1,0 +1,15 @@
+import { Wallet } from "src/modules/user/wallets/types";
+
+export function getBlockchainLink(wallets: Wallet[], currency: string, txid: string, rid?: string) {
+    const currencyInfo = wallets && wallets.find(wallet => wallet.currency === currency);
+    if (currencyInfo) {
+        if (txid && currencyInfo.explorerTransaction) {
+            return currencyInfo.explorerTransaction.replace('#{txid}', txid);
+        }
+        if (rid && currencyInfo.explorerAddress) {
+            return currencyInfo.explorerAddress.replace('#{address}', rid);
+        }
+    }
+    return '';
+}
+

--- a/web/src/helpers/index.ts
+++ b/web/src/helpers/index.ts
@@ -49,4 +49,3 @@ export * from './ssToMMSS';
 export * from './mergeObjects';
 export * from './validateBeneficiaryTestnetAddress';
 export * from './validateBeneficiaryAddress';
-export * from './transferLinks';

--- a/web/src/helpers/transferLinks.tsx
+++ b/web/src/helpers/transferLinks.tsx
@@ -1,8 +1,0 @@
-export interface TransferLink {
-  'title': string;
-  'url': string;
-}
-
-export interface TransferLinks {
-  [index: number]: TransferLink;
-}

--- a/web/src/hooks/useT.ts
+++ b/web/src/hooks/useT.ts
@@ -1,0 +1,9 @@
+import { useIntl } from 'react-intl';
+
+export type TranslateFn = (id: string) => string;
+
+export const useT = (): TranslateFn => {
+    const { formatMessage } = useIntl();
+
+    return (id: string) => formatMessage({ id });
+};

--- a/web/src/modules/user/history/types.ts
+++ b/web/src/modules/user/history/types.ts
@@ -61,6 +61,13 @@ export interface Deposit {
     completed_at: string;
     state: string;
     price?: number;
+    public_message?: string;
+    transfer_links?: TransferLink[];
+}
+
+export interface TransferLink {
+    title: string;
+    url: string;
 }
 
 export type WalletHistoryElement = Withdraw | Deposit | PrivateTrade;

--- a/web/src/translations/en.ts
+++ b/web/src/translations/en.ts
@@ -322,6 +322,7 @@ export const en = {
     'page.body.history.deposit.content.status.processing': 'Processing',
     'page.body.history.deposit.content.status.fee_processing': 'Processing',
     'page.body.history.deposit.content.status.errored': 'Errored',
+    'page.body.history.deposit.content.status.refunding': 'Refunding',
 
     'page.body.history.withdraw': 'Withdrawal History',
     'page.body.history.withdraw.header.id': 'ID',


### PR DESCRIPTION
- Все статусы окрашиваются в три цвета - зеленый, желтый, красный
- Единое отображение для Wallets, History и мобильной версии

Отображение
* `dispatched` - зеленая иконка галочка
* `errored` - красный Errored или `public_message`
* `skipped` - красный Skipped
* `rejected` -красный Сanceled
* `submitted` - желтый `Processing` 
* `invoiced` - желтые `transfer_links` (ссылки)
* `canceled` - красный  Сanceled
* `accepted` - желтый Pending confirmations/min_confirmations (ссылка)
* `refunding` - желтый Refunding