### PR TITLE
Use hash when fetching the env.js

### DIFF
--- a/web/src/app/template.html
+++ b/web/src/app/template.html
@@ -13,10 +13,10 @@
         <title>Bitzlato</title>
     </head>
     <body>
-        <% if (htmlWebpackPlugin.options.mock) { %>
+        <% if (process.env.MOCK) { %>
             <script src="/config.js"></script>
         <% } else { %>
-            <script src="/config/env.js"></script>
+            <script src="/config/env.js?<%= process.env.HASH %>"></script>
         <% } %>
         <noscript>
             You need to enable JavaScript to run this app.

--- a/web/webpack/common.ts
+++ b/web/webpack/common.ts
@@ -22,7 +22,7 @@ const config: webpack.Configuration = {
     },
     plugins: [
         new webpack.EnvironmentPlugin({
-            envType: 'dev',
+            MOCK: false,
         }),
         new HtmlWebpackPlugin({
             template: path.resolve(rootDir, 'src/app/template.html'),

--- a/web/webpack/development.ts
+++ b/web/webpack/development.ts
@@ -1,27 +1,16 @@
 import { HotModuleReplacementPlugin } from 'webpack';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import HtmlWebpackPlugin from 'html-webpack-plugin';
 import path from 'path';
 import merge from 'webpack-merge';
 import 'webpack-dev-server';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
-
 import commonConfig from './common';
-const rootDir = path.resolve(__dirname, '..');
+
 const host = process.env.PROXY_HOST;
 
 const config = merge(commonConfig, {
     devtool: 'cheap-module-eval-source-map',
-    plugins: [
-        new HotModuleReplacementPlugin(),
-        new ForkTsCheckerWebpackPlugin({}),
-        new HtmlWebpackPlugin({
-            template: path.resolve(rootDir, 'src/app/template.html'),
-            hash: true,
-            chunks: ['common', 'bundle', 'styles'],
-            mock: process.env.MOCK,
-        }),
-    ],
+    plugins: [new HotModuleReplacementPlugin(), new ForkTsCheckerWebpackPlugin({})],
     module: {
         rules: [
             {

--- a/web/webpack/production.ts
+++ b/web/webpack/production.ts
@@ -15,6 +15,7 @@ const BUILD_DIR = path.resolve(rootDir, 'build');
 import commonConfig from './common';
 import { extractSemver } from './semver';
 
+const HASH = Math.round(Date.now() / 1000).toString();
 const domain = process.env.BUILD_DOMAIN ? process.env.BUILD_DOMAIN.split(',') : [];
 const appVersion = extractSemver(readFileSync('../.semver').toString());
 
@@ -24,7 +25,8 @@ const plugins = [
         BUILD_EXPIRE: null,
         REACT_APP_BUGSNAG_KEY: null,
         REACT_APP_BUGSNAG_VERSION: appVersion,
-        REACT_APP_BUGSNAG_RELEASE_STAGE: 'development'
+        REACT_APP_BUGSNAG_RELEASE_STAGE: 'development',
+        HASH
     }),
     new OptimizeCssAssetsPlugin({
         assetNameRegExp: /\.css$/g,


### PR DESCRIPTION
При запросе env.js добавляется `?<timestamp>`, чтобы при обновлении env.js не брался старый из кеша