### PR TITLE
Change header origin while proxying the websocket request

### DIFF
--- a/web/webpack/development.ts
+++ b/web/webpack/development.ts
@@ -111,7 +111,9 @@ const config = merge(commonConfig, {
                       target: `wss://${host}`,
                       changeOrigin: true,
                       ws: true,
-                      onProxyReqWs: (proxyReq, req, socket) => {
+                      onProxyReqWs: (proxyReq, _, socket) => {
+                          proxyReq.removeHeader('origin');
+                          proxyReq.setHeader('origin', `https://${host}`);
                           socket.on('error', error => {});
                       },
                   },


### PR DESCRIPTION
Не знаю по какой причине, но origin запроса не менялся и вебсокет соединение сбрасывалось.
Теперь `make start_baseapp_proxy PROXY_HOST=market.bitzlato.com` работает