### PR TITLE
chore: swith off the warning with "Conflicting order"

### DIFF
--- a/web/webpack/common.ts
+++ b/web/webpack/common.ts
@@ -36,6 +36,7 @@ const config: webpack.Configuration = {
     new MiniCssExtractPlugin({
       filename: '[name].[contenthash].css',
       chunkFilename: '[id].[contenthash].css',
+      ignoreOrder: true,
     }),
   ],
   optimization: {


### PR DESCRIPTION
отключил предупреждение при сборке:
```
WARNING in chunk 2 [mini-css-extract-plugin]
Conflicting order. Following module has been added:
```