### PR TITLE
fix: wallet banner with locked/available amounts on mobile

### DIFF
--- a/web/src/components/Box/Box.postcss
+++ b/web/src/components/Box/Box.postcss
@@ -1,3 +1,9 @@
+.rowSpacingSm {
+  & > *:not(:first-child) {
+    margin-left: calc(var(--gap) / 2);
+  }
+}
+
 .rowSpacing {
   & > *:not(:first-child) {
     margin-left: var(--gap);
@@ -16,6 +22,18 @@
   }
 }
 
+.rowSpacing4X {
+  & > *:not(:first-child) {
+    margin-left: calc(var(--gap) * 4);
+  }
+}
+
+.colSpacingSm {
+  & > *:not(:first-child) {
+    margin-top: calc(var(--gap) / 2);
+  }
+}
+
 .colSpacing {
   & > *:not(:first-child) {
     margin-top: var(--gap);
@@ -31,6 +49,12 @@
 .colSpacing3X {
   & > *:not(:first-child) {
     margin-top: calc(var(--gap) * 3);
+  }
+}
+
+.colSpacing4X {
+  & > *:not(:first-child) {
+    margin-top: calc(var(--gap) * 4);
   }
 }
 
@@ -54,6 +78,10 @@
 
 .justifyBetween {
   justify-content: space-between;
+}
+
+.justifyCenter {
+  justify-content: center;
 }
 
 .alignCenter {

--- a/web/src/components/Box/index.tsx
+++ b/web/src/components/Box/index.tsx
@@ -13,10 +13,11 @@ type BoxOwnProps<E = React.ElementType> = {
   grow?: boolean;
   justifyEnd?: boolean;
   justifyBetween?: boolean;
+  justifyCenter?: boolean;
   alignCenter?: boolean;
   selfStart?: boolean;
   wrap?: boolean;
-  spacing?: boolean | '2x' | '3x';
+  spacing?: boolean | '2x' | '3x' | '4x' | 'sm';
   padding?: '2x' | '3x';
 };
 
@@ -39,6 +40,7 @@ export const Box: Element = React.forwardRef(
       alignCenter,
       justifyEnd,
       justifyBetween,
+      justifyCenter,
       selfStart,
       wrap,
       ...props
@@ -54,14 +56,19 @@ export const Box: Element = React.forwardRef(
       alignCenter && s.alignCenter,
       justifyEnd && s.justifyEnd,
       justifyBetween && s.justifyBetween,
+      justifyCenter && s.justifyCenter,
       selfStart && s.selfStart,
       wrap && s.wrap,
       row && spacing === true && s.rowSpacing,
       row && spacing === '2x' && s.rowSpacing2X,
       row && spacing === '3x' && s.rowSpacing3X,
+      row && spacing === '4x' && s.rowSpacing4X,
+      row && spacing === 'sm' && s.rowSpacingSm,
       col && spacing === true && s.colSpacing,
       col && spacing === '2x' && s.colSpacing2X,
       col && spacing === '3x' && s.colSpacing3X,
+      col && spacing === '4x' && s.colSpacing4X,
+      col && spacing === 'sm' && s.colSpacingSm,
       padding === '2x' && s.padding2X,
       padding === '3x' && s.padding3X
     );

--- a/web/src/mobile/components/WalletBanner/index.tsx
+++ b/web/src/mobile/components/WalletBanner/index.tsx
@@ -1,46 +1,50 @@
 import * as React from 'react';
-import { useIntl } from 'react-intl';
-import { Decimal } from '../../../components/Decimal';
-import { DEFAULT_CCY_PRECISION } from '../../../constants';
+import { Box } from 'src/components/Box';
+import { CurrencyTicker } from 'src/components/CurrencyTicker/CurrencyTicker';
+import { Label } from 'src/components/Label/Label';
+import { ccy, money, MoneyFormat } from 'src/components/MoneyFormat/MoneyFormat';
+import { useT } from 'src/hooks/useT';
+import { Wallet } from 'src/modules/user/wallets/types';
 import { areEqualSelectedProps } from '../../../helpers/areEqualSelectedProps';
 
 interface Props {
-  wallet: any;
+  wallet: Wallet;
 }
 
-const WalletBannerComponent = (props: Props) => {
-  const {
-    wallet: { currency, balance = 0, locked = 0, fixed = DEFAULT_CCY_PRECISION },
-  } = props;
-  const intl = useIntl();
+const WalletBannerComponent: React.FC<Props> = ({ wallet }) => {
+  const t = useT();
+
+  const mccy = ccy(wallet.currency, wallet.fixed);
 
   return (
-    <div className="cr-wallet-banner-mobile">
-      <div className="cr-wallet-banner-mobile__item">
-        <span className="cr-wallet-banner-mobile__item-title">
-          {intl.formatMessage({ id: 'page.mobile.wallets.banner.total' })}
-        </span>
-        <div className="cr-wallet-banner-mobile__item-info">
-          <Decimal fixed={fixed} children={+(balance || 0) + +(locked || 0)} />
-          <span className="cr-wallet-banner-mobile__item-info-currency">{currency}</span>
-        </div>
-      </div>
-      <div className="cr-wallet-banner-mobile__item">
-        <span className="cr-wallet-banner-mobile__item-title">
-          {intl.formatMessage({ id: 'page.mobile.wallets.banner.available' })}
-        </span>
-        <div className="cr-wallet-banner-mobile__item-info">
-          <Decimal fixed={fixed} children={balance || 0} />
-          <span className="cr-wallet-banner-mobile__item-info-currency">{currency}</span>
-        </div>
-      </div>
-    </div>
+    <Box padding="2x" row spacing="4x" justifyCenter className="cr-wallet-banner-mobile">
+      <Box col spacing="sm">
+        <Label size="sm">{t('page.mobile.wallets.banner.locked')}</Label>
+        <Box row wrap spacing="sm">
+          <Label primaryColor>
+            <MoneyFormat money={money(wallet.locked || 0, mccy)} />
+          </Label>
+          <Label primaryColor>
+            <CurrencyTicker symbol={wallet.currency} />
+          </Label>
+        </Box>
+      </Box>
+      <Box col spacing="sm">
+        <Label size="sm">{t('page.mobile.wallets.banner.available')}</Label>
+        <Box row wrap spacing="sm">
+          <Label primaryColor>
+            <MoneyFormat money={money(wallet.balance || 0, mccy)} />
+          </Label>
+          <Label primaryColor>
+            <CurrencyTicker symbol={wallet.currency} />
+          </Label>
+        </Box>
+      </Box>
+    </Box>
   );
 };
 
-const WalletBanner = React.memo(
+export const WalletBanner = React.memo(
   WalletBannerComponent,
   areEqualSelectedProps('wallet', ['balance', 'locked', 'currency', 'fixed']),
 );
-
-export { WalletBanner };

--- a/web/src/mobile/screens/SelectedWalletScreen/index.tsx
+++ b/web/src/mobile/screens/SelectedWalletScreen/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router';
+import { defaultWallet } from 'src/modules/user/wallets/defaults';
 import { useWalletsFetch } from '../../../hooks';
 import { selectWallets } from '../../../modules/user/wallets';
 import { Subheader, WalletBanner, WalletHeader, WalletsButtons } from '../../components';
@@ -13,11 +14,7 @@ const SelectedWalletMobileScreen = () => {
   const history = useHistory();
   const wallets = useSelector(selectWallets) || [];
 
-  const wallet = wallets.find((item) => item.currency === currency) || {
-    name: '',
-    currency: '',
-    icon_id: '',
-  };
+  const wallet = wallets.find((item) => item.currency === currency) || defaultWallet;
 
   useWalletsFetch();
 

--- a/web/src/mobile/screens/WalletWithdraw/index.tsx
+++ b/web/src/mobile/screens/WalletWithdraw/index.tsx
@@ -3,19 +3,10 @@ import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router';
 import { useMemberLevelFetch } from 'src/hooks/useMemberLevelsFetch';
+import { defaultWallet } from 'src/modules/user/wallets/defaults';
 import { useWalletsFetch } from '../../../hooks';
 import { selectWallets } from '../../../modules/user/wallets';
 import { Subheader, WalletBanner, WalletHeader, WalletWithdrawBody } from '../../components';
-
-const defaultWallet = {
-  name: '',
-  currency: '',
-  balance: '',
-  type: '',
-  address: '',
-  fee: '',
-  icon_id: '',
-};
 
 const WalletWithdraw: React.FC = () => {
   const { currency = '' } = useParams();

--- a/web/src/mobile/styles/components/WalletBanner.pcss
+++ b/web/src/mobile/styles/components/WalletBanner.pcss
@@ -1,34 +1,6 @@
 /* stylelint-disable */
 .cr-wallet-banner-mobile {
-  height: 87px;
   background: var(--body-background-color);
   margin-top: 4px;
   margin-bottom: 4px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  &__item {
-    display: flex;
-    flex-direction: column;
-
-    &-title {
-      font-size: 12px;
-    }
-
-    &-info {
-      font-size: 16px;
-
-      &-currency {
-        text-transform: uppercase;
-        font-size: 16px;
-        color: var(--primary-text-color);
-        padding-left: 5px;
-      }
-    }
-
-    &:first-child {
-      margin-right: 32px;
-    }
-  }
 }

--- a/web/src/mobile/translations/en.ts
+++ b/web/src/mobile/translations/en.ts
@@ -56,8 +56,8 @@ export const en = {
 
   'page.mobile.wallets.deposit.history': 'Deposit history',
   'page.mobile.wallets.withdraw.history': 'Withdraw history',
-  'page.mobile.wallets.banner.total': 'Total',
   'page.mobile.wallets.banner.available': 'Available',
+  'page.mobile.wallets.banner.locked': 'Locked',
 
   'page.mobile.copy.text': 'Copy Address',
   'page.mobile.wallet.deposit.generate': 'Generate deposit address',

--- a/web/src/mobile/translations/ru.ts
+++ b/web/src/mobile/translations/ru.ts
@@ -56,8 +56,8 @@ export const ru = {
 
   'page.mobile.wallets.deposit.history': 'История депозита',
   'page.mobile.wallets.withdraw.history': 'История вывода',
-  'page.mobile.wallets.banner.total': 'Всего',
   'page.mobile.wallets.banner.available': 'Доступно',
+  'page.mobile.wallets.banner.locked': 'Заблокировано',
 
   'page.mobile.copy.text': 'Скопировать адресс',
   'page.mobile.wallet.deposit.generate': 'Сгенерировать адресс депозита',

--- a/web/src/modules/user/wallets/defaults.ts
+++ b/web/src/modules/user/wallets/defaults.ts
@@ -1,0 +1,12 @@
+import { DEFAULT_CCY_PRECISION } from "src/constants";
+import { Wallet } from "./types";
+
+export const defaultWallet: Wallet = {
+  name: '',
+  currency: '',
+  balance: '',
+  type: 'coin',
+  fixed: DEFAULT_CCY_PRECISION,
+  fee: 0,
+  icon_id: '',
+};


### PR DESCRIPTION
Additional:
- Total replaced with Locked like on the desktop version

<img width="340" alt="Screenshot 2021-10-23 at 17 31 53" src="https://user-images.githubusercontent.com/12247182/138560711-585982c8-8716-42de-80b0-c9a02d2a0cb0.png">
