### PR TITLE
fix: hide absent markets in the "Quick Exchange"

### DIFF
--- a/web/src/containers/QuickExchange/AmountDescription.tsx
+++ b/web/src/containers/QuickExchange/AmountDescription.tsx
@@ -36,10 +36,8 @@ export const AmountDescription: React.FC<AmountDescriptionProps> = ({
 
     if ((maxAmount.isZero() && fromAmount) || amount.greaterThan(maxAmount)) {
       return (
-        <Box as="span">
-          <Box as="span" textColor="failed">
-            {t('page.body.quick.exchange.insufficient_balance')}
-          </Box>
+        <Box as="span" textColor="failed">
+          <Box as="span">{t('page.body.quick.exchange.insufficient_balance')}</Box>
           &nbsp;
           <Box as={Link} to={`/wallets/${fromCurrency}/deposit`} className={s.link}>
             {t('page.body.quick.exchange.top_up_balance')}

--- a/web/src/containers/QuickExchange/QuickExchange.postcss
+++ b/web/src/containers/QuickExchange/QuickExchange.postcss
@@ -56,10 +56,10 @@
 }
 
 .link {
-  color: var(--header-nav-item-color);
+  color: inherit;
+  text-decoration: underline;
 
   &:hover {
     color: var(--header-nav-item-color-hover);
-    text-decoration: underline;
   }
 }

--- a/web/src/containers/QuickExchange/helpers.test.tsx
+++ b/web/src/containers/QuickExchange/helpers.test.tsx
@@ -1,0 +1,46 @@
+import { Market } from 'src/modules/public/markets/types';
+import { getCurrencies } from './helpers';
+
+function getMarketsLike(pairs: [string, string][]): Market[] {
+  return pairs.map(([from, to]) => ({ base_unit: from, quote_unit: to } as Market));
+}
+
+const markets = getMarketsLike([
+  ['btc', 'usdt'],
+  ['eth', 'btc'],
+  ['eth', 'mcr'],
+]);
+
+describe('getCurrencies', () => {
+  test('should process bad "from"', () => {
+    const d = getCurrencies(markets, '', '');
+    expect(d.fromList).toEqual(['btc', 'eth', 'mcr', 'usdt']);
+    expect(d.toList).toEqual([]);
+    expect(d.market).toBeUndefined();
+    expect(d.recommendTo).toBeUndefined();
+  });
+
+  test('should process bad "to"', () => {
+    const d = getCurrencies(markets, 'btc', '');
+    expect(d.fromList).toEqual(['btc', 'eth', 'mcr', 'usdt']);
+    expect(d.toList).toEqual(['eth', 'usdt']);
+    expect(d.market).toBeUndefined();
+    expect(d.recommendTo).toBe('usdt');
+  });
+
+  test('should process bad "to" and without usdt market', () => {
+    const d = getCurrencies(markets, 'eth', 'usdt2');
+    expect(d.fromList).toEqual(['btc', 'eth', 'mcr', 'usdt']);
+    expect(d.toList).toEqual(['btc', 'mcr']);
+    expect(d.market).toBeUndefined();
+    expect(d.recommendTo).toBe('btc');
+  });
+
+  test('should process existing market', () => {
+    const d = getCurrencies(markets, 'btc', 'usdt');
+    expect(d.fromList).toEqual(['btc', 'eth', 'mcr', 'usdt']);
+    expect(d.toList).toEqual(['eth', 'usdt']);
+    expect(d.market).toBeDefined();
+    expect(d.recommendTo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- upper dropdown shows all available currencies
- bottom dropdown shows only existing markets with the upper
- if not found a market with the new upper currency, the bottom will be reset