### PR TITLE
chore(build): Enable stats saving to internal folder

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -10,3 +10,5 @@ stats.json
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+/statoscope-reports

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -194,7 +194,11 @@ module.exports = {
   },
 
   plugins: [
-    process.env.ANALYZE && new StatoscopeWebpackPlugin(),
+    process.env.ANALYZE &&
+      new StatoscopeWebpackPlugin({
+        name: 'baseapp',
+        saveStatsTo: 'statoscope-reports/stats-[name]-[hash].json',
+      }),
 
     !isDevelopment &&
       new CopyWebpackPlugin({


### PR DESCRIPTION
Полезно для сохранения статистики о продакшн билдах и последующего анализа.

Например, как сравнить свою ветку с мастером:
1. Находясь в ветке `master` сделать билд с анализом: `ANALYZE=1 yarn build`
2. Перейти в другую ветку `git checkout feat/foo` и сделать билд с анализом: `ANALYZE=1 yarn build`
3. Теперь можно запустить statoscope чтобы собрать отчет: `yarn dlx @statoscope/cli generate --input statoscope-reports/stats-baseapp-*.json --output statoscope-reports/report.html`
4. Открыть в браузере `statoscope-reports/report.html` и в разделе Diff сравнить две статистики.