### PR TITLE
fix: show dash symbol when no p2p balance [#181157839]

### DIFF
--- a/web/src/components/AmountFormat/AmountFormat.tsx
+++ b/web/src/components/AmountFormat/AmountFormat.tsx
@@ -5,12 +5,12 @@ import s from './AmountFormat.postcss';
 
 type Renderer = (amountFormatted: string) => ReactElement;
 
-interface Props extends FormatOptions {
+export interface AmountFormatProps extends FormatOptions {
   money: Money;
   children?: Renderer;
 }
 
-export const AmountFormat: FC<Props> = ({ money, children, ...options }: Props) => {
+export const AmountFormat: FC<AmountFormatProps> = ({ money, children, ...options }) => {
   const amountFormatted = money.toFormat(options);
 
   if (children) {

--- a/web/src/components/Format/NoAmountFormat.tsx
+++ b/web/src/components/Format/NoAmountFormat.tsx
@@ -1,0 +1,15 @@
+import { FC, ReactElement, ReactNode } from 'react';
+import { Money } from '@bitzlato/money-js';
+import { AmountFormat, AmountFormatProps } from 'web/src/components/AmountFormat/AmountFormat';
+
+interface Props extends Omit<AmountFormatProps, 'money'> {
+  money: Money | undefined;
+}
+
+export const NoAmountFormat: FC<Props> = ({ money, ...rest }) => {
+  if (money === undefined) {
+    return '–' as ReactNode & ReactElement; // en dash
+  }
+
+  return <AmountFormat {...rest} money={money} />;
+};

--- a/web/src/components/WalletItem/WalletItem.tsx
+++ b/web/src/components/WalletItem/WalletItem.tsx
@@ -12,8 +12,8 @@ export interface WalletItemData {
   name: string;
   currency: string;
   balance: Money;
-  balanceP2P: Money;
-  balanceMarket: Money;
+  balanceP2P: Money | undefined;
+  balanceMarket: Money | undefined;
   approximate: Money;
   locked: Money;
   icon: string;

--- a/web/src/containers/Withdraw/WithdrawSummary.tsx
+++ b/web/src/containers/Withdraw/WithdrawSummary.tsx
@@ -4,6 +4,7 @@ import { AmountFormat } from 'src/components/AmountFormat/AmountFormat';
 import { useT } from 'src/hooks/useT';
 import { MoneyFormat } from 'src/components/MoneyFormat/MoneyFormat';
 import { createMoney } from 'src/helpers/money';
+import { NoAmountFormat } from 'web/src/components/Format/NoAmountFormat';
 import { SummaryField } from '../../components';
 import { BlockchainCurrencyMoney, Wallet } from '../../modules';
 
@@ -19,7 +20,7 @@ export const WithdrawSummary: React.FC<Props> = ({ wallet, total, blockchainCurr
   return (
     <Box flex1 col spacing="sm">
       <SummaryField message={t('page.body.wallets.tabs.withdraw.content.fee')}>
-        {blockchainCurrency ? <AmountFormat money={blockchainCurrency.withdraw_fee} /> : '-'}
+        <NoAmountFormat money={blockchainCurrency?.withdraw_fee} />
       </SummaryField>
       <SummaryField message={t('page.body.wallets.tabs.withdraw.content.total')}>
         <AmountFormat money={createMoney(total || 0, wallet.currency)} />

--- a/web/src/mobile/screens/SelectedWalletScreen/WalletMobileBalance.tsx
+++ b/web/src/mobile/screens/SelectedWalletScreen/WalletMobileBalance.tsx
@@ -5,6 +5,7 @@ import { CryptoCurrencyIcon } from 'src/components/CryptoCurrencyIcon/CryptoCurr
 import { getCurrencyCodeSymbol } from 'src/helpers/getCurrencySymbol';
 import { AmountFormat } from 'src/components/AmountFormat/AmountFormat';
 import { useT } from 'src/hooks/useT';
+import { NoAmountFormat } from 'web/src/components/Format/NoAmountFormat';
 
 interface Props {
   wallet: WalletItemData;
@@ -28,13 +29,13 @@ export const WalletMobileBalance: React.FC<Props> = ({ wallet }) => {
         <Box row spacing justify="between">
           <span>{t('P2P Balance')}</span>
           <span>
-            <AmountFormat money={wallet.balanceP2P} />
+            <NoAmountFormat money={wallet.balanceP2P} />
           </span>
         </Box>
         <Box row spacing justify="between">
           <span>{t('Exchange Balance')}</span>
           <span>
-            <AmountFormat money={wallet.balanceMarket} />
+            <NoAmountFormat money={wallet.balanceMarket} />
           </span>
         </Box>
         <Box row spacing justify="between">

--- a/web/src/mobile/screens/SelectedWalletScreen/WalletMobileScreen.tsx
+++ b/web/src/mobile/screens/SelectedWalletScreen/WalletMobileScreen.tsx
@@ -90,8 +90,8 @@ export const WalletMobileScreen: React.FC = () => {
                 {general.hasTransfer && (
                   <Transfer
                     currency={general.balance.currency}
-                    balanceMarket={general.balanceMarket.toString()}
-                    balanceP2P={general.balanceP2P.toString()}
+                    balanceMarket={general.balanceMarket?.toString() ?? '0'}
+                    balanceP2P={general.balanceP2P?.toString() ?? '0'}
                     transfers={transfers}
                     onChangeTransfers={() => setTransfers(transfers + 1)}
                   />

--- a/web/src/screens/WalletsScreen/Balance.tsx
+++ b/web/src/screens/WalletsScreen/Balance.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Money } from '@bitzlato/money-js';
 import { Box } from 'src/components/Box/Box';
-import { AmountFormat } from 'src/components/AmountFormat/AmountFormat';
 import s from './Balance.postcss';
+import { NoAmountFormat } from 'web/src/components/Format/NoAmountFormat';
 
 interface BalanceProps {
   title: string;
-  money: Money;
+  money: Money | undefined;
 }
 
 export const Balance: React.FC<BalanceProps> = (props) => {
@@ -14,7 +14,7 @@ export const Balance: React.FC<BalanceProps> = (props) => {
     <Box flex1 padding="3" col justify="between" className={s.balance}>
       <Box textSize="lg">{props.title}</Box>
       <Box style={{ fontSize: 30 }}>
-        <AmountFormat money={props.money} />
+        <NoAmountFormat money={props.money} />
       </Box>
     </Box>
   );

--- a/web/src/screens/WalletsScreen/WalletsScreen.tsx
+++ b/web/src/screens/WalletsScreen/WalletsScreen.tsx
@@ -170,8 +170,8 @@ export const WalletsScreen: React.FC = () => {
                       {item.hasTransfer && (
                         <Transfer
                           currency={item.balance.currency}
-                          balanceMarket={item.balanceMarket.toString()}
-                          balanceP2P={item.balanceP2P.toString()}
+                          balanceMarket={item.balanceMarket?.toString() ?? '0'}
+                          balanceP2P={item.balanceP2P?.toString() ?? '0'}
                           transfers={transfers}
                           onChangeTransfers={() => setTransfers(transfers + 1)}
                         />

--- a/web/src/screens/WalletsScreen/helpers.ts
+++ b/web/src/screens/WalletsScreen/helpers.ts
@@ -18,7 +18,7 @@ export function getList(wallets: Wallet[], balances: GeneralBalance[]): WalletIt
       currency: ccy.code,
       icon: wallet.icon_id,
       balance,
-      balanceP2P: createMoney(item?.p2p_balance ?? 0, ccy),
+      balanceP2P: item?.p2p_balance ? createMoney(item.p2p_balance, ccy) : undefined,
       balanceMarket: item?.market_balance ? createMoney(item.market_balance, ccy) : wallet.balance,
       locked: item ? getLocked(ccy, item) : wallet.locked,
       approximate: createMoney(wallet.price, PENCE_CCY).multiply(balance.toString()),


### PR DESCRIPTION
Чтобы локализовать использование прочерка, добавил компонент `NoAmountFormat`

![Screenshot 2022-02-10 at 19 05 32](https://user-images.githubusercontent.com/12247182/153448137-07e8732a-d865-4b3a-b876-8c833baad84e.png)
