### PR TITLE
fix: change old order's market name

### DIFF
--- a/web/src/components/MarketName/MarketName.tsx
+++ b/web/src/components/MarketName/MarketName.tsx
@@ -10,7 +10,12 @@ export const MarketName: FC<Props> = ({ name }: Props) => {
 
   return (
     <>
-      <CurrencyTicker symbol={from} />/<CurrencyTicker symbol={to} />
+      <CurrencyTicker symbol={from} />
+      {to !== undefined && (
+        <>
+          /<CurrencyTicker symbol={to} />
+        </>
+      )}
     </>
   );
 };

--- a/web/src/containers/OrdersElement/index.tsx
+++ b/web/src/containers/OrdersElement/index.tsx
@@ -155,7 +155,7 @@ class OrdersComponent extends React.PureComponent<Props, OrdersState> {
       created_at,
     } = item;
     const currentMarket = this.props.marketsData.find((m) => m.id === market) || {
-      name: '',
+      name: market.split('_').join('/').toUpperCase(),
       price_precision: 0,
       amount_precision: 0,
     };


### PR DESCRIPTION
Изменения понадобились, потому что в текущих маркетах может не найтись ид маркета у ордера, причем у совсем старых вообще нет разделителей
![Screenshot 2022-02-15 at 13 54 42](https://user-images.githubusercontent.com/12247182/154048767-3250ac72-0871-41ff-99c7-b8691e9510fd.png)
