### PR TITLE
fix: Fix define window.AUTH0_DOMAIN and window.AUTH0_CLIENT_ID

### DIFF
--- a/web/src/app/template.html
+++ b/web/src/app/template.html
@@ -58,8 +58,8 @@
     <% } else { %>
     <script>
       (function () {
-        window.AUTH0_DOMAIN = '<%= process.env.AUTH0_DOMAIN %>';
-        window.AUTH0_CLIENT_ID = '<%= process.env.AUTH0_CLIENT_ID %>';
+        window.AUTH0_DOMAIN = <%= JSON.stringify(process.env.AUTH0_DOMAIN) %>;
+        window.AUTH0_CLIENT_ID = <%= JSON.stringify(process.env.AUTH0_CLIENT_ID) %>;
       })();
     </script>
     <script src="/config/env.js?<%= process.env.HASH %>"></script>


### PR DESCRIPTION
Исправляю поведение, когда не определена `process.env.AUTH0_DOMAIN`, то подставляется пустая строка `''`
Было
```
window.AUTH0_DOMAIN = '';
window.AUTH0_CLIENT_ID = '';
```

Стало
```
window.AUTH0_DOMAIN = null;
window.AUTH0_CLIENT_ID = null;
```