### PR TITLE
fix: Revert publicPath value to 'auto'

### DIFF
--- a/web/src/publicPath.ts
+++ b/web/src/publicPath.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error
+__webpack_public_path__ = process.env.ASSET_PATH;

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
   devtool: isDevelopment ? 'eval-cheap-module-source-map' : 'hidden-source-map',
 
   entry: {
-    bundle: './src/index.ts',
+    bundle: ['./src/publicPath.ts', './src/index.ts'],
   },
 
   output: {
@@ -55,7 +55,7 @@ module.exports = {
     filename: !isDevelopment ? '[name].[contenthash].js' : undefined,
     chunkFilename: '[id].[contenthash].js',
     globalObject: 'this',
-    publicPath: '/',
+    publicPath: 'auto',
     clean: true,
   },
 
@@ -226,6 +226,7 @@ module.exports = {
       }),
 
     new webpack.EnvironmentPlugin({
+      ASSET_PATH: '/',
       MOCK: false,
       BUILD_EXPIRE: null,
       HASH,
@@ -247,6 +248,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: './src/app/template.html',
       hash: true,
+      publicPath: '/',
     }),
 
     new webpack.ProvidePlugin({


### PR DESCRIPTION
- `publicPath: 'auto'` нужен, чтобы не было проблем при использовании shared компонентов на p2p
- А чтобы не было проблем с загрузкой чанков на бирже – меняем publicPath на лету