### PR TITLE
feat: Add truncation of rating line in profile stats

### DIFF
--- a/web/src/components/profile/Profile.tsx
+++ b/web/src/components/profile/Profile.tsx
@@ -14,6 +14,7 @@ import { useTradeStats } from 'web/src/hooks/data/useFetchTradeStatistics';
 import { Skeleton } from 'web/src/components/ui/Skeleton';
 import { selectMobileDeviceState } from 'web/src/modules/public/globalSettings/selectors';
 import { useFetchSessionsMe } from 'web/src/hooks/data/useFetchSessionsMe';
+import { parseAmount } from 'web/src/helpers/parseAmount';
 import { ProfileDealsStats } from './ProfileDealsStats';
 import * as s from './Profile.css';
 import { ProfileVerification } from './ProfileVerification';
@@ -66,7 +67,14 @@ export const Profile: FC = () => {
             <div className={s.stat}>
               <Stat>
                 <StatLabel>{t('Rating')}</StatLabel>
-                <StatValue>{user.bitzlato_user.user_profile.rating ?? <Skeleton />}</StatValue>
+                <Text
+                  as="div"
+                  variant="h3"
+                  textOverflow="ellipsis"
+                  title={user.bitzlato_user.user_profile.rating}
+                >
+                  {parseAmount(user.bitzlato_user.user_profile.rating, 4)}
+                </Text>
               </Stat>
             </div>
             <div className={s.stat}>
@@ -118,7 +126,7 @@ export const Profile: FC = () => {
           <Box display="flex" justifyContent="space-between">
             <Text variant="label">{t('Rating')}</Text>
             <Text variant="label" fontWeight="strong">
-              {user.bitzlato_user.user_profile.rating ?? <Skeleton />}
+              {parseAmount(user.bitzlato_user.user_profile.rating, 4)}
             </Text>
           </Box>
           <Box display="flex" justifyContent="space-between">

--- a/web/src/components/ui/Text.tsx
+++ b/web/src/components/ui/Text.tsx
@@ -17,10 +17,12 @@ interface Props
         | 'whiteSpace'
         | 'color'
         | 'lineHeight'
+        | 'textOverflow'
       >
     > {
   as?: ElementType | undefined;
   className?: string | undefined;
+  title?: string | undefined;
 }
 
 const variantMapping: Record<NonNullable<Props['variant']>, keyof JSX.IntrinsicElements> = {

--- a/web/src/helpers/parseAmount.test.ts
+++ b/web/src/helpers/parseAmount.test.ts
@@ -1,0 +1,13 @@
+import { parseAmount } from './parseAmount';
+
+describe('parseAmount', () => {
+  test('should parse amount', () => {
+    expect(parseAmount('', 2)).toEqual('');
+    expect(parseAmount('0', 2)).toEqual('0');
+    expect(parseAmount('99', 2)).toEqual('99');
+    expect(parseAmount('99.1234', 2)).toEqual('99.12');
+    expect(parseAmount('99.1234', 0)).toEqual('99');
+    expect(parseAmount('99.1234', 5)).toEqual('99.1234');
+    expect(parseAmount('99.123456789', 8)).toEqual('99.12345678');
+  });
+});

--- a/web/src/helpers/parseAmount.ts
+++ b/web/src/helpers/parseAmount.ts
@@ -1,0 +1,15 @@
+import { parseNumeric } from './parseNumeric';
+
+export const parseAmount = (amount: string, maxFractionDigits: number): string => {
+  const numeric = parseNumeric(amount);
+  const [integer, fractional] = numeric.split('.');
+  if (typeof integer === 'string' && maxFractionDigits === 0) {
+    return integer;
+  }
+
+  if (typeof fractional === 'string' && fractional.length > maxFractionDigits) {
+    return `${integer}.${fractional.slice(0, maxFractionDigits)}`;
+  }
+
+  return numeric;
+};

--- a/web/src/screens/tests/__snapshots__/ProfileScreen.test.tsx.snap
+++ b/web/src/screens/tests/__snapshots__/ProfileScreen.test.tsx.snap
@@ -92,11 +92,12 @@ exports[`ProfileScreen test should render 1`] = `
               >
                 Rating
               </span>
-              <span
-                class="reset_base__1sfgjt80 sprinkles_color_text_default__w76aifs7 Text_text__1qy84op6 Text__1qy84op0 sprinkles_fontFamily_brand__w76aif19k Text_text_variant_h3__1qy84op9 Text_text_gutterBottom_false__1qy84opj "
+              <div
+                class="reset_base__1sfgjt80 sprinkles_color_text_default__w76aifs7 sprinkles_textOverflow_ellipsis__w76aif19t Text_text__1qy84op6 Text__1qy84op0 sprinkles_fontFamily_brand__w76aif19k Text_text_variant_h3__1qy84op9 Text_text_gutterBottom_false__1qy84opj "
+                title="0.0"
               >
                 0.0
-              </span>
+              </div>
             </div>
           </div>
           <div

--- a/web/src/theme/sprinkles.css.ts
+++ b/web/src/theme/sprinkles.css.ts
@@ -152,6 +152,13 @@ const typographyProperties = defineProperties({
     textAlign: ['left', 'center'],
     textTransform: ['uppercase'],
     whiteSpace: ['nowrap'],
+    textOverflow: {
+      ellipsis: {
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+      },
+    },
   },
 });
 


### PR DESCRIPTION
- `parseAmount` - полезная функция, для ограничения цифр после запятой

![Снимок экрана 2022-03-18 в 17 59 31](https://user-images.githubusercontent.com/2435004/159027653-fae32a51-e820-4792-8284-b5e50c969969.png)
