### PR TITLE
fix: add some improvements to Gifts [#181695481]

### DIFF
--- a/web/src/custom/translations/ru.ts
+++ b/web/src/custom/translations/ru.ts
@@ -1360,6 +1360,8 @@ export const ru: LangType = {
   Created: 'Созданные',
   More: 'Дополнительно',
   'Send an email again': 'Отправить письмо еще раз',
+  'Balance is insufficient': 'Недостаточно средств',
+  'Could not be less than 1': 'Сумма не может быть меньше 1',
 
   'deposit.usdx.e':
     'Принимаются только депозиты токенов {currency}, будьте внимательны при отправке средств!',

--- a/web/src/helpers/fetch.ts
+++ b/web/src/helpers/fetch.ts
@@ -18,7 +18,7 @@ export const fetchJson = async (input: RequestInfo, init: RequestInit) => {
         throw new FetchError(errors, res.status, rest);
       }
 
-      throw new FetchError(error ? [error] : ['Server error'], res.status, rest);
+      throw new FetchError([error ?? rest.message ?? 'Server error'], res.status, rest);
     }
 
     return json;

--- a/web/src/hooks/data/useFetchRate.ts
+++ b/web/src/hooks/data/useFetchRate.ts
@@ -1,0 +1,16 @@
+import { p2pUrl } from 'web/src/api/config';
+import { buildQueryString } from 'web/src/helpers/buildQueryString';
+import { fetchWithCreds } from 'web/src/helpers/fetch';
+import { CurrencyRate } from 'web/src/modules/user/profile/types';
+import { useFetch } from './useFetch';
+
+export const useFetchRate = (cryptoCurrency: string, fiatCurrency: string | undefined) => {
+  return useFetch<CurrencyRate>(
+    fiatCurrency
+      ? `${p2pUrl()}/profile/rate-sources/${cryptoCurrency}?${buildQueryString({
+          currency: fiatCurrency,
+        })}`
+      : null,
+    fetchWithCreds,
+  );
+};

--- a/web/src/modules/user/profile/types.ts
+++ b/web/src/modules/user/profile/types.ts
@@ -128,3 +128,10 @@ export interface ReferralLink {
   type: string;
   url: string;
 }
+
+export interface CurrencyRate {
+  description: string;
+  url: string;
+  id: number;
+  rate: number;
+}

--- a/web/src/translations/en.ts
+++ b/web/src/translations/en.ts
@@ -1338,6 +1338,8 @@ export const en = {
   Created: 'Created',
   More: 'More',
   'Send an email again': 'Send an email again',
+  'Balance is insufficient': 'Balance is insufficient',
+  'Could not be less than 1': 'Could not be less than 1',
 
   'deposit.usdx.e':
     'Only deposits of {currency} tokens are accepted, be careful when sending funds!',


### PR DESCRIPTION
- Писать так же сумму Примерно в фиате
- Кнопки % (25,50,75,100) должны брать сумму от фиата, а не от крипты
- В созданном/обналиченном чеках писать валюту, в которой был создан, а не в USD
- Добавить информативности на две ошибки: нельзя выписать чек в фиате меньше 1 ,а больше чем на кошельке.
- При вводе суммы в фиате - показывать сколько это эквивалентно в крипте

![Screenshot 2022-03-28 at 15 14 05](https://user-images.githubusercontent.com/12247182/160406057-829650f4-14ee-4439-bb21-9132e762edf6.png)
