### PR TITLE
Revert "fix: Use type property in gift links"

### DIFF
--- a/web/src/containers/Gift/Gift.tsx
+++ b/web/src/containers/Gift/Gift.tsx
@@ -422,7 +422,7 @@ export const Gift: FC<Props> = (props) => {
                   variant="outlined"
                   onClick={() => copyToClip(l.url)}
                 >
-                  {l.type}
+                  {l.label}
                 </Button>
               ))}
             </Box>


### PR DESCRIPTION
This reverts commit c088d41d4ef46dffa19df6fea734bb12d5ff90b6.

Изменили API, добавили поле 
Теперь ответ по линкам такой
```
{
	"type": "telegram",
	"label": "Telegram bot @xxx",
	"url": "xxx"
}
```