### PR TITLE
chore: Disable some eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,11 +27,15 @@
         "react/function-component-definition": [
           "error",
           { "namedComponents": "arrow-function", "unnamedComponents": "arrow-function" }
-        ], // override Airbnb rule
+        ],
+
+        // override Airbnb rule
         "react/jsx-props-no-spreading": "off", // override Airbnb rule
         "react/prop-types": "off",
         "react/react-in-jsx-scope": "off", // Disabled for React 17
         "react/require-default-props": "off", // override Airbnb rule
+        "no-nested-ternary": "off",
+        "@typescript-eslint/no-use-before-define": "off",
 
         // typescript
         "@typescript-eslint/no-explicit-any": "warn"


### PR DESCRIPTION
Предложение по выключению некоторых правил `eslint`

- no-nested-ternary

чтобы в jsx коде иметь возможность писать
```
{!wallet?.deposit_enabled ? (
  <Blur text={t('page.body.wallets.tabs.deposit.disabled.message')} />
) : user.level < (memberLevels?.deposit.minimum_level ?? 0) ? (
  <Blur
    text={t('page.body.wallets.warning.deposit.verification')}
    onClick={() => history.push('/confirm')}
    linkText={t('page.body.wallets.warning.deposit.verification.button')}
  />
) : null}
```
инчае надо вводить дополнительную переменную

- @typescript-eslint/no-use-before-define

чтобы второстепенные константы и вспомогательные функции размещать в конце файла, в начале же будет главное

