### PR TITLE
fix: Set full width for mobile container at Board [#181865520]

### DIFF
--- a/web/src/components/shared/Ads/Board.tsx
+++ b/web/src/components/shared/Ads/Board.tsx
@@ -97,7 +97,7 @@ export const Board: FC = () => {
 
   if (isMobileDevice) {
     return (
-      <Box display="flex" flexDirection="column">
+      <Box display="flex" flexDirection="column" width="full">
         <Box m="5x" display="flex" flexDirection="column" gap="6x">
           {navs}
           <Box display="flex" flexDirection="column" gap="4x">


### PR DESCRIPTION
<img width="727" alt="image" src="https://user-images.githubusercontent.com/10403829/170288559-6a341c5c-e254-4a8e-b2a7-f8f7b585a214.png">
фикс этого