### PR TITLE
fix: Change use of dropdown color to layoutBg color

### DIFF
--- a/web/src/components/shared/Ads/Ad.tsx
+++ b/web/src/components/shared/Ads/Ad.tsx
@@ -277,7 +277,7 @@ export const Ad: FC = () => {
       <Box
         display="flex"
         flexDirection="column"
-        backgroundColor="dropdown"
+        backgroundColor="layoutBg"
         m="8x"
         borderRadius="1.5x"
         overflow="hidden"

--- a/web/src/components/shared/Ads/Board.tsx
+++ b/web/src/components/shared/Ads/Board.tsx
@@ -181,7 +181,7 @@ export const Board: FC = () => {
             <FilterMobile params={filterParams} onChange={handleChangeFilter} />
           </Box>
         </Box>
-        <Box px="5x" py="4x" backgroundColor="dropdown">
+        <Box px="5x" py="4x" backgroundColor="layoutBg">
           {ads}
         </Box>
       </Box>
@@ -195,7 +195,7 @@ export const Board: FC = () => {
       </Box>
       <Box display="flex" p="8x">
         <Box
-          backgroundColor="dropdown"
+          backgroundColor="layoutBg"
           p="6x"
           borderRadius="1.5x"
           marginRight="6x"
@@ -203,7 +203,7 @@ export const Board: FC = () => {
         >
           <Filter params={filterParams} onChange={handleChangeFilter} />
         </Box>
-        <Box backgroundColor="dropdown" py="5x" px="6x" borderRadius="1.5x" flexGrow={1}>
+        <Box backgroundColor="layoutBg" py="5x" px="6x" borderRadius="1.5x" flexGrow={1}>
           {ads}
         </Box>
       </Box>

--- a/web/src/components/shared/Trader/Trader.tsx
+++ b/web/src/components/shared/Trader/Trader.tsx
@@ -26,14 +26,14 @@ export const Trader: FC = () => {
       <Box display="flex" p="8x" height="full">
         <Box
           display="flex"
-          backgroundColor="dropdown"
+          backgroundColor="layoutBg"
           borderRadius="1.5x"
           marginRight="6x"
           style={{ width: '20%', minWidth: '380px' }}
         >
           <TraderInfo publicName={params.name} />
         </Box>
-        <Box backgroundColor="dropdown" py="5x" px="6x" borderRadius="1.5x" flexGrow={1}>
+        <Box backgroundColor="layoutBg" py="5x" px="6x" borderRadius="1.5x" flexGrow={1}>
           <TraderAds data={data} isLoading={isValidating} />
           {data && !isValidating && (
             <Pagination

--- a/web/src/components/traderInfo/TraderInfo.tsx
+++ b/web/src/components/traderInfo/TraderInfo.tsx
@@ -48,7 +48,7 @@ export const TraderInfo: FC<TraderInfoProps> = ({ publicName }) => {
       p="3x"
       display="flex"
       flexDirection="column"
-      backgroundColor="dropdown"
+      backgroundColor="layoutBg"
       className={styles.sideBlock}
     >
       <Box mb="4x" pb="4x" borderBottomWidth="1x" borderColor="traderBorder" borderStyle="solid">

--- a/web/src/theme/vars.css.ts
+++ b/web/src/theme/vars.css.ts
@@ -273,6 +273,8 @@ export const [themeLight, vars] = createTheme({
     bottomTabsIconActive: colors.goldTips,
     bottomTabsText: colors.ebonyClay70,
     bottomTabsTextActive: colors.goldTips,
+
+    layoutBg: colors.white,
   },
 });
 
@@ -483,5 +485,7 @@ export const themeDark = createTheme(vars, {
     bottomTabsIconActive: colors.goldTips,
     bottomTabsText: colors.white50,
     bottomTabsTextActive: colors.goldTips,
+
+    layoutBg: colors.ebonyClay,
   },
 });


### PR DESCRIPTION
Для фона использовали цвет "dropdown", который был изменен по дизайну в PR для SharedHeader

Поэтому вынес нужный цвет в "layoutBg"

До:
<img width="1351" alt="image" src="https://user-images.githubusercontent.com/10403829/171442340-92df9c68-ca9a-4416-9c13-d4fe7c7b5c8d.png">

После:
<img width="1351" alt="image" src="https://user-images.githubusercontent.com/10403829/171441953-93412972-07b2-47e6-bd60-34bb470310dd.png">
