### PR TITLE
fix: Getting global timestamp in trades filter date

### DIFF
--- a/web/src/components/shared/Trades/TradesFilter.tsx
+++ b/web/src/components/shared/Trades/TradesFilter.tsx
@@ -12,6 +12,7 @@ import { TextInput } from 'web/src/components/TextInputCustom/TextInputCustom';
 import { parseNumeric } from 'web/src/helpers/parseNumeric';
 import { SelectCustom } from 'web/src/components/SelectCustom/SelectCustom';
 import { InputDate } from 'web/src/components/shared/InputDate/InputDate';
+import { getTimestampWithoutTimezone } from 'web/src/helpers/getTimestamp';
 import FilterIcon from 'web/src/assets/svg/FilterIcon.svg';
 
 const TODAY = new Date();
@@ -144,7 +145,7 @@ const FilterControls: FC<Props> = ({ params, onChange }) => {
       return;
     }
 
-    const time = value.getTime();
+    const time = getTimestampWithoutTimezone(value);
     if (!time || time < 0) {
       return;
     }
@@ -160,7 +161,7 @@ const FilterControls: FC<Props> = ({ params, onChange }) => {
       return;
     }
 
-    const time = value.getTime();
+    const time = getTimestampWithoutTimezone(value);
     if (!time || time < 0) {
       return;
     }

--- a/web/src/helpers/getTimestamp.ts
+++ b/web/src/helpers/getTimestamp.ts
@@ -1,0 +1,6 @@
+export const getTimestampWithoutTimezone = (date: Date) => {
+  const time = date.getTime();
+  const userTimezoneOffset = date.getTimezoneOffset() * 60000;
+
+  return time - userTimezoneOffset;
+};


### PR DESCRIPTION
<img width="707" alt="Screenshot 2022-07-12 at 09 43 41" src="https://user-images.githubusercontent.com/10403829/178430896-362aee1a-d717-4f51-9b5e-40d6232b32cc.png">

фильтр на бэке принимает timestamp независимо от таймзоны (в GMT), а getTime выдает timestamp который вычисляется относительно таймзоны. Поэтому для получения нужной - вычел из getTime - getTimezoneOffset 