### PR TITLE
chore: Refactoring MoneyCurrency type

### DIFF
--- a/web/src/hooks/data/useFetchP2PCurrencies.ts
+++ b/web/src/hooks/data/useFetchP2PCurrencies.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from 'react';
 import { p2pUrl } from 'web/src/api/config';
 import { P2PCurrencies, P2PCurrencyOption } from 'web/src/modules/public/currencies/types';
-import { MoneyCurrency } from 'web/src/types';
+import { BaseCurrency } from 'web/src/types/currencies.types';
 import { useFetch, FetchResponse } from './useFetch';
 
-export type FiatCurrencies = Record<string, MoneyCurrency>;
+export type FiatCurrencies = Record<string, BaseCurrency>;
 
 const DEFAULT_FIAT_MINOR_UNIT = 2;
 
@@ -32,7 +32,7 @@ export const useP2PCurrencyOptions = (): FetchResponse<P2PCurrencyOption[]> => {
 };
 
 export const useFiatCurrencies = (): {
-  getFiatCurrency: (code: string) => MoneyCurrency;
+  getFiatCurrency: (code: string) => BaseCurrency;
   fiatCurrencies?: FiatCurrencies | undefined;
   error: unknown;
 } => {
@@ -40,7 +40,7 @@ export const useFiatCurrencies = (): {
 
   const fiatCurrencies = useMemo(() => {
     if (data) {
-      return data.reduce<Record<string, MoneyCurrency>>((acc, P2PCurrency) => {
+      return data.reduce<Record<string, BaseCurrency>>((acc, P2PCurrency) => {
         acc[P2PCurrency.code] = {
           code: P2PCurrency.code,
           name: P2PCurrency.name,
@@ -55,7 +55,7 @@ export const useFiatCurrencies = (): {
     return undefined;
   }, [data]);
   const getFiatCurrency = useCallback(
-    (code: string): MoneyCurrency =>
+    (code: string): BaseCurrency =>
       fiatCurrencies?.[code] ?? {
         code,
         name: code,

--- a/web/src/hooks/data/useUserAds.ts
+++ b/web/src/hooks/data/useUserAds.ts
@@ -2,7 +2,7 @@ import { Money } from '@bitzlato/money-js';
 import { p2pUrl } from 'web/src/api/config';
 import { fetchJson } from 'web/src/helpers/fetch';
 import { PaymethodSource } from 'web/src/modules/p2p/types';
-import { MoneyCurrency } from 'web/src/types';
+import { BaseCurrency } from 'web/src/types/currencies.types';
 import { useCryptoCurrencies } from '../useCryptoCurrencies';
 import { useFetch } from './useFetch';
 import { useFiatCurrencies } from './useFetchP2PCurrencies';
@@ -50,8 +50,8 @@ export interface TraderAdvert
     max: Money;
     realMax: Money | null;
   };
-  currency: MoneyCurrency;
-  cryptoCurrency: MoneyCurrency;
+  currency: BaseCurrency;
+  cryptoCurrency: BaseCurrency;
 }
 
 export const useUserAds = ({ publicName, lang }: { publicName: string; lang: string }) => {

--- a/web/src/hooks/useCryptoCurrencies.ts
+++ b/web/src/hooks/useCryptoCurrencies.ts
@@ -1,4 +1,4 @@
-import { MoneyCurrency } from 'web/src/types';
+import { BaseCurrency } from 'web/src/types/currencies.types';
 
 const MINOR_UNIT_MAP: Record<string, number> = {
   BTC: 8,
@@ -14,7 +14,7 @@ const MINOR_UNIT_MAP: Record<string, number> = {
   MDT: 8,
 };
 
-const cryptoCurrencies = Object.keys(MINOR_UNIT_MAP).reduce<Record<string, MoneyCurrency>>(
+const cryptoCurrencies = Object.keys(MINOR_UNIT_MAP).reduce<Record<string, BaseCurrency>>(
   (acc, code) => {
     acc[code] = { code, name: code, sign: code, minorUnit: MINOR_UNIT_MAP[code] ?? 8 };
     return acc;
@@ -22,7 +22,7 @@ const cryptoCurrencies = Object.keys(MINOR_UNIT_MAP).reduce<Record<string, Money
   {},
 );
 
-const getCryptoCurrency = (code: string): MoneyCurrency => {
+const getCryptoCurrency = (code: string): BaseCurrency => {
   const maybeMoneyCurrency = cryptoCurrencies[code];
 
   return (
@@ -31,6 +31,6 @@ const getCryptoCurrency = (code: string): MoneyCurrency => {
 };
 
 export const useCryptoCurrencies = (): {
-  getCryptoCurrency: (code: string) => MoneyCurrency;
-  cryptoCurrencies: Record<string, MoneyCurrency>;
+  getCryptoCurrency: (code: string) => BaseCurrency;
+  cryptoCurrencies: Record<string, BaseCurrency>;
 } => ({ getCryptoCurrency, cryptoCurrencies });

--- a/web/src/hooks/useP2PWalletOptions.ts
+++ b/web/src/hooks/useP2PWalletOptions.ts
@@ -1,8 +1,8 @@
 import { Money } from '@bitzlato/money-js';
 import { useMemo } from 'react';
-import { useUser } from '../components/app/AppContext';
-import { createMoney } from '../helpers/money';
-import { MoneyCurrency } from '../types';
+import { useUser } from 'web/src/components/app/AppContext';
+import { createMoney } from 'web/src/helpers/money';
+import { BaseCurrency } from 'web/src/types/currencies.types';
 import { useFetchP2PCryptoCurrencies, useFetchP2PWalletsV2 } from './data/useFetchP2PWallets';
 import { useCryptoCurrencies } from './useCryptoCurrencies';
 
@@ -15,7 +15,7 @@ export interface P2PWalletOption {
 
 export function useP2PWalletOptions(
   cryptocurrency: string,
-  getFiatCurrency: (code: string) => MoneyCurrency,
+  getFiatCurrency: (code: string) => BaseCurrency,
 ) {
   const user = useUser();
   const { getCryptoCurrency } = useCryptoCurrencies();

--- a/web/src/modules/p2p/trade.types.ts
+++ b/web/src/modules/p2p/trade.types.ts
@@ -1,4 +1,4 @@
-import { MoneyCurrency } from 'web/src/types';
+import { BaseCurrency } from 'web/src/types/currencies.types';
 import { AdvertType, P2PCryptoCurrency, PaymethodSource } from './types';
 
 export type TradeType = AdvertType;
@@ -27,6 +27,6 @@ export interface TradeSource {
 
 export interface Trade extends Omit<TradeSource, 'currency' | 'cryptocurrency' | 'paymethod'> {
   paymethod: PaymethodSource;
-  currency: P2PCryptoCurrency & { moneyCurrency: MoneyCurrency };
-  cryptoCurrency: P2PCryptoCurrency & { moneyCurrency: MoneyCurrency };
+  currency: P2PCryptoCurrency & { moneyCurrency: BaseCurrency };
+  cryptoCurrency: P2PCryptoCurrency & { moneyCurrency: BaseCurrency };
 }

--- a/web/src/modules/p2p/types.ts
+++ b/web/src/modules/p2p/types.ts
@@ -1,5 +1,5 @@
 import { Money } from '@bitzlato/money-js';
-import { MoneyCurrency } from 'web/src/types';
+import { BaseCurrency } from 'web/src/types/currencies.types';
 
 export interface CurrencyRate {
   description: string;
@@ -168,8 +168,8 @@ export interface Advert
     max: Money;
     realMax?: Money | undefined;
   };
-  currency: MoneyCurrency;
-  cryptoCurrency: MoneyCurrency;
+  currency: BaseCurrency;
+  cryptoCurrency: BaseCurrency;
 }
 
 export interface PaymethodSource {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,4 +1,3 @@
-import { Currency } from '@bitzlato/money-js';
 import { WrappedComponentProps } from 'react-intl';
 
 export type IntlProps = WrappedComponentProps;
@@ -9,8 +8,3 @@ export type Theme = 'light' | 'dark';
 export type OptionalWithUndefined<T> = {
   [P in keyof T]: Pick<T, P> extends Required<Pick<T, P>> ? T[P] : T[P] | undefined;
 };
-
-export interface MoneyCurrency extends Currency {
-  name: string;
-  sign: string;
-}

--- a/web/src/types/currencies.types.ts
+++ b/web/src/types/currencies.types.ts
@@ -1,0 +1,6 @@
+import { Currency } from '@bitzlato/money-js';
+
+export interface BaseCurrency extends Currency {
+  name: string;
+  sign: string;
+}


### PR DESCRIPTION
Переименовал `MoneyCurrency` в `BaseCurrency` и переместил его в отдельный файл `web/src/types/currencies.types.ts`
Планирую в ближайшее время рефакторить запросы на получение валют от бэка и использовать `BaseCurrency` как основной тип для них.