### PR TITLE
fix: Set paymethod from slug and fix update paymethod slug when removed

### DIFF
--- a/web/src/components/shared/Ads/useBoardFilter.ts
+++ b/web/src/components/shared/Ads/useBoardFilter.ts
@@ -169,19 +169,18 @@ export const useBoardFilter = ({
         ..._upd,
       };
 
+      const next = {
+        ...filterParams,
+        ...upd,
+      };
+
       let paymethod;
       if ('paymethod' in upd) {
         paymethod = upd.paymethod
           ? paymethods?.find((item) => item.id === upd.paymethod)
           : undefined;
-      }
 
-      const next = {
-        ...filterParams,
-        ...upd,
-      };
-      if (paymethod) {
-        next.paymethodSlug = paymethod.slug;
+        next.paymethodSlug = paymethod?.slug ?? undefined;
       }
 
       setFilterParams(next);
@@ -227,6 +226,20 @@ export const useBoardFilter = ({
       ),
     );
   }, [filter, filterParams, handleChangeFilter, history, lang, paymethods]);
+
+  useEffect(() => {
+    if (
+      paymethods &&
+      paymethods.length > 0 &&
+      !filterParams.paymethod &&
+      filterParams.paymethodSlug
+    ) {
+      handleChangeFilter({
+        paymethod: paymethods?.find((paymethod) => paymethod.slug === filterParams.paymethodSlug)
+          ?.id,
+      });
+    }
+  }, [filterParams, paymethods, handleChangeFilter]);
 
   useEffect(() => {
     if (!cryptoCurrencies?.some((currency) => currency.code === filterParams.cryptocurrency)) {


### PR DESCRIPTION
```при открытии ссылки https://bitzlato.bz/en/p2p/buy-btc-rub-tinkoff payment method не применяется из урла, похоже на баг```

- добавил проверку paymethod в эффекте - если его нет а slug есть, то ищем по slug
- добавил в обновление фильтра, очистку paymethodSlug