### PR TITLE
fix: Fix adding a new line for ctrl+enter in textarea chat [#182961530]

### DIFF
--- a/web/src/components/shared/Chat/ChatControls.tsx
+++ b/web/src/components/shared/Chat/ChatControls.tsx
@@ -35,10 +35,17 @@ export const ChatControls: FC<Props> = ({
   };
 
   const handleTextKeyPress: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
-    if (event.key === 'Enter' && !event.shiftKey && !event.ctrlKey) {
-      event.preventDefault();
+    if (event.key === 'Enter') {
+      if (!event.shiftKey && !event.ctrlKey) {
+        event.preventDefault();
 
-      submit();
+        submit();
+        return;
+      }
+
+      if (event.ctrlKey) {
+        setText(`${text}\n`);
+      }
     }
   };
 


### PR DESCRIPTION
Оказывается ctrl+enter новую строку не добавляет. Добавил нужное.