### PR TITLE
fix: Limit input for requisites to 30 symbols

### DIFF
--- a/web/src/components/TextInputCustom/DetailsInput.tsx
+++ b/web/src/components/TextInputCustom/DetailsInput.tsx
@@ -5,6 +5,7 @@ import cn from 'classnames';
 import { IconButton } from 'web/src/components/IconButton/IconButton';
 import { useSharedT } from 'web/src/components/shared/Adapter';
 import { useOnClickOutside } from 'web/src/hooks/useOnClickOutside';
+import { MAX_AD_DETAILS_LENGTH } from 'web/src/components/shared/CreateAd/StepTerms';
 import { TextAreaInput } from './TextInputCustom';
 import * as s from './DetailsInput.css';
 
@@ -50,7 +51,7 @@ export const DetailsInput: FC<Props> = ({
         className={inputClassName}
         rows={rows}
         spellCheck={false}
-        maxLength={400}
+        maxLength={MAX_AD_DETAILS_LENGTH}
         icon={
           lastDetails.length > 0 && (
             <IconButton onClick={toggleOptions}>

--- a/web/src/components/shared/CreateAd/StepTerms.tsx
+++ b/web/src/components/shared/CreateAd/StepTerms.tsx
@@ -12,7 +12,7 @@ import { StepSubmitRow } from './StepSubmitRow';
 type FieldKeys = 'terms' | 'details';
 
 export const MAX_AD_TERMS_LENGTH = 3000;
-export const MAX_AD_DETAILS_LENGTH = 700;
+export const MAX_AD_DETAILS_LENGTH = 50;
 const DEFAULT_ROWS = 6;
 
 interface Props {

--- a/web/src/components/shared/UserAd/UserAdRequisitesStep.tsx
+++ b/web/src/components/shared/UserAd/UserAdRequisitesStep.tsx
@@ -5,7 +5,6 @@ import { UserAdvertDetails } from 'web/src/modules/p2p/types';
 import { useAdapterContext } from 'web/src/components/shared/Adapter';
 import { useFetchLastRequisites } from 'web/src/hooks/data/useFetchTrade';
 import { DetailsInput } from 'web/src/components/TextInputCustom/DetailsInput';
-import { CollapsibleText } from 'web/src/components/shared/CollapsibleText/CollapsibleText';
 import { UserAdBlock } from './UserAdBlock';
 import { UserAdField } from './UserAdField';
 import { EditCheckbox } from './EditCheckbox';
@@ -57,6 +56,7 @@ export const UserAdRequisitesStep: FC<Props> = ({ ad }) => {
               error={formErrors?.details}
               value={
                 <DetailsInput
+                  rows={2}
                   inputClassName={s.textareaInput}
                   lastDetails={lastDetails}
                   isError={Boolean(formErrors?.details)}
@@ -65,7 +65,9 @@ export const UserAdRequisitesStep: FC<Props> = ({ ad }) => {
                 />
               }
               readOnlyValue={
-                <CollapsibleText text={ad.details ?? ''} textColor="textMuted" fontSize="small" />
+                <Text variant="body" color="textMuted">
+                  {ad.details ?? ''}
+                </Text>
               }
             />
           </Box>


### PR DESCRIPTION
Ограничил ввод реквизитов до 30 символов, иначе бэк все равно отрезает до 30 символов